### PR TITLE
Fixing scene.ray_cast after API update

### DIFF
--- a/fsc_add_object_op.py
+++ b/fsc_add_object_op.py
@@ -112,7 +112,7 @@ class FSC_OT_Add_Oject_Operator(Operator):
         rot         = (0,0,0)  
 
         # Get intersection and create objects at this location if possible
-        hit, loc_hit, norm, face, *_ = scene.ray_cast(context.view_layer, origin, view_vector)
+        hit, loc_hit, norm, face, *_ = scene.ray_cast(context.view_layer.depsgraph, origin, view_vector)
         if hit:
             loc = loc_hit
             z = Vector((0,0,1))


### PR DESCRIPTION
In Blender 2.91, the method `context.scene.ray_cast` now requires accessing the `depsgraph` object on `context.view_layer`.